### PR TITLE
Fixed an issue signal binding event forwarding method was generating incorrect parameters.

### DIFF
--- a/addons/csharp_wrapper_generator_for_gdextension/TypeModels.cs
+++ b/addons/csharp_wrapper_generator_for_gdextension/TypeModels.cs
@@ -541,8 +541,11 @@ public partial class WrapperGeneratorMain
 
         public void RenderGDExtensionToWrapper(StringBuilder builder, GenerationLogger logger)
         {
-            if (!IsGDExtensionType) 
+            if (!IsGDExtensionType)
+            {
                 logger.Add($"{Type} is not a GDExtension type");
+                return;
+            }
 
             var godotClass = (GodotClassType)Type;
             builder.Append(godotClass.CSharpTypeName);


### PR DESCRIPTION
This PR fixes an issue:

When the signal parameter of a GDExtension type is itself a GDExtension type, the binding event forwarding method was generating incorrect parameters.

Added an `IsGDExtensionType` property to `GodotClassType`, `GodotPropertyInfo` , and `GodotMethodArgument` to detect whether the current property is a GDExtension type.

Added a `RenderGDExtensionToWrapper` method to `GodotPropertyInfo` to generate code that converts a Variant to the C# wrapper type when the property is a GDExtension type:

`WrapperType.Bind(CSharpNameEscapedString.As<CSharpMarshallingTypeName>())`

**Before:**

```csharp
    public new delegate void AnimationCompletedSignalHandler(SpineSprite spineSprite, SpineAnimationState animationState, SpineTrackEntry trackEntry);
    private AnimationCompletedSignalHandler _animationCompletedSignal;
    private Callable _animationCompletedSignalCallable;
    public event AnimationCompletedSignalHandler AnimationCompletedSignal
    {
        add
        {
            if (_animationCompletedSignal is null)
            {
                _animationCompletedSignalCallable = Callable.From((Variant spineSprite, Variant animationState, Variant trackEntry) => 
                    _animationCompletedSignal?.Invoke(spineSprite.As<Node2D>()), animationState.As<RefCounted>(),  trackEntry.As<RefCounted>()));
                Connect(GDExtensionSignalName.AnimationCompleted, _animationCompletedSignalCallable);
            }
            _animationCompletedSignal += value;
        }
       // ...
    }
```

**After:**

```csharp
    public new delegate void AnimationCompletedSignalHandler(SpineSprite spineSprite, SpineAnimationState animationState, SpineTrackEntry trackEntry);
    private AnimationCompletedSignalHandler _animationCompletedSignal;
    private Callable _animationCompletedSignalCallable;
    public event AnimationCompletedSignalHandler AnimationCompletedSignal
    {
        add
        {
            if (_animationCompletedSignal is null)
            {
                _animationCompletedSignalCallable = Callable.From((Variant spineSprite, Variant animationState, Variant trackEntry) => 
                    _animationCompletedSignal?.Invoke(SpineSprite.Bind(spineSprite.As<Node2D>()), SpineAnimationState.Bind(animationState.As<RefCounted>()), SpineTrackEntry.Bind(trackEntry.As<RefCounted>())));
                Connect(GDExtensionSignalName.AnimationCompleted, _animationCompletedSignalCallable);
            }
            _animationCompletedSignal += value;
        }
        // ...
    }
```