### PR TITLE
Generate Node extension to get wrapped nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ To create a GDExtension type instance, call `TypeName.Instantiate()`.
 
 To bind (wrap) a GDExtension type instance, call `TypeName.Bind(instance)`.
 
+To load and bind (wrap) a `Resource`-derived GDExtension type from a path, call `TypeName.Load(path)`.
+
 #### API Support
 
 The following type members are supported by the wrappers:
@@ -106,6 +108,11 @@ public partial class Test : Node
         gdCubismParameterWrapper.DefaultValue = -20;
         GD.Print(gdCubismParameterWrapper.DefaultValue);
 
+        // This loads and wraps an existing Resource-derived GDExtension type.
+        // The developer should ensure the supplied Godot object matches the underlying GDExtension type.
+        var spineSkeleton = SpineSkeletonDataResource.Load("res://path/to/resource.tres");
+        GD.Print(spineSkeleton.GetSkeletonName());
+
         // Accessing the properties and methods from
         // an exported wrapper type. The developer 
         // has to attach the wrapper script to that
@@ -148,6 +155,8 @@ public partial class Test : Node
 要创建一个 GDExtension 类型实例，请调用 `TypeName.Instantiate()`。
 
 要绑定（包装）一个 GDExtension 类型实例，请调用 `TypeName.Bind(instance)`。
+
+要从路径加载并绑定（包装）一个派生自`Resource`类的 GDExtension 类型资源，请调用 `TypeName.Load(path)`。
 
 #### API 支持
 
@@ -229,6 +238,11 @@ public partial class Test : Node
         GD.Print(gdCubismParameterWrapper.DefaultValue);
         gdCubismParameterWrapper.DefaultValue = -20;
         GD.Print(gdCubismParameterWrapper.DefaultValue);
+        
+        // 这将从指定路径加载并包装一个现有的资源类型。
+        // 开发者应确保提供的 Godot 匹配底层的 GDExtension 类型。
+        var spineSkeleton = SpineSkeletonDataResource.Load("res://path/to/resource.tres");
+        GD.Print(spineSkeleton.GetSkeletonName());
 
         // 访问导出的包装器类型的属性和方法。
         // 开发者必须将包装器脚本附加到该 GDExtension 节点实例才能工作。

--- a/addons/csharp_wrapper_generator_for_gdextension/TypeModels.cs
+++ b/addons/csharp_wrapper_generator_for_gdextension/TypeModels.cs
@@ -38,6 +38,18 @@ public partial class WrapperGeneratorMain
 
             return depth;
         }
+
+        public bool IsInheritedFrom(GodotName other)
+        {
+            var currentType = ParentType;
+            while (currentType != null)
+            {
+                if (currentType.GodotTypeName == other) return true;
+                currentType = (currentType as GodotClassType)?.ParentType;
+            }
+
+            return false;
+        }
         
         public GodotNamedType ParentType { get; set; }
         public List<GodotFunctionInfo> Methods { get; } = [];
@@ -63,6 +75,7 @@ public partial class WrapperGeneratorMain
         private const string BindMethodName = "Bind";
         private const string TypeGDExtensionCacheName = "NativeName";
         private const string WrapperConstructorName = "Instantiate";
+        private const string WrapperResourceLoadMethodName = "Load";
 
         public void RenderClass(StringBuilder classBuilder, string nameSpace, string indent, GenerationLogger logger)
         {
@@ -151,6 +164,21 @@ public partial class WrapperGeneratorMain
                      {indent}/// </summary>
                      {indent}/// <returns>The wrapper instance linked to the underlying GDExtension "{GodotTypeName}" type.</returns>
                      {indent}public new static {CSharpTypeName} {WrapperConstructorName}() => {BindMethodName}(ClassDB.Instantiate({TypeGDExtensionCacheName}).As<GodotObject>());
+
+                     """
+                );
+            }
+
+            if (IsInheritedFrom(new GodotName("Resource")))
+            {
+                classBuilder.AppendLine(
+                    $"""
+                     {indent}/// <summary>
+                     {indent}/// Loads the resource at the specified path, then attaches the corresponding wrapper script instance.
+                     {indent}/// </summary>
+                     {indent}/// <param name="path">The resource path to load.</param>
+                     {indent}/// <returns>The wrapper instance linked to the underlying GDExtension "{GodotTypeName}" type.</returns>
+                     {indent}public new static {CSharpTypeName} {WrapperResourceLoadMethodName}(string path) => {BindMethodName}(ResourceLoader.Load(path));
 
                      """
                 );


### PR DESCRIPTION
Add a Node extension helper so generated wrappers expose a Get{TypeName}Node method that resolves a child node and binds (or attaches) the corresponding wrapper. TypeModels.cs: introduce GetNodeHelperClassName and emit a GetNodeExtension static partial class with Get{CSharpTypeName}Node(this Node, NodePath) => {Type}.Bind(node.GetNode(path)). README.md: document the new Node extension (English and Chinese) and add usage examples showing how to retrieve and use a GDExtension node wrapper from the scene tree.

Generate context:

```csharp

public static partial class GetNodeExtension
{
    /// <summary>
    /// Gets the node at the specified <paramref name="path"/>, then casts its attached script to the <see cref="SpineSprite"/> wrapper type.
    /// If no wrapper script is attached, or the attached script does not inherit <see cref="SpineSprite"/>, a new wrapper script instance is attached.
    /// </summary>
    /// <remarks>The developer must ensure the node at the given path represents the correct underlying GDExtension type.</remarks>
    /// <param name="node">The parent node from which the target node is resolved.</param>
    /// <param name="path">The child node path to resolve.</param>
    /// <returns>The existing or newly attached <see cref="SpineSprite"/> wrapper instance.</returns>
    public static SpineSprite GetSpineSpriteNode(this Node node, NodePath path)
        => SpineSprite.Bind(node.GetNode(path));
}

[Tool]
public partial class SpineSprite : Node2D
{
    // ....
}

```